### PR TITLE
Maven publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ We use Kochiku to build or SDK and our sample app.
 #### Sample App
 
 The sample app is build via [this job](https://kochiku.sqprod.co/squareup/android-cash-paykit-sdk), and uploads the APK to [go/mr](https://mobile-releases.squareup.com/cash-apps)
+
+
+### RELEASING
+The SDK artifact will be deployed as an AAR to our public [artifactory repository](https://artifactory.global.square/ui/repos/tree/General/releases/)
+
+#### Locally
+1.) Ensure connection to SQ VPN
+2.) Update `LIB_VERSION` in build.gradle
+3.) Ensure your username and [Artifactory API key](https://artifactory.global.square/artifactory/webapp/#/profile) are available as SONATYPE_NEXUS_USERNAME and SONATYPE_NEXUS_PASSWORD  in ~/.gradle/gradle.properties (or you can add them with additional -P flags on the next step's command).
+4.) Run ./gradlew publish -PRELEASE_REPOSITORY_URL="https://maven.global.square/artifactory/releases"

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
   id 'com.android.library' version '7.3.1' apply false
   id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
   id "com.diffplug.spotless" version "6.12.1"
+  id 'maven-publish'
 }
 
 subprojects { subproject ->

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     lifecycle_version = '2.5.1'
     mockk_version = '1.13.3'
     coroutines_test_version = '1.6.4'
-    robolectric_version = '4.9'
+    robolectric_version = '4.9.2'
     mockwebserver_version = '4.10.0'
   }
 }

--- a/paykit/build.gradle
+++ b/paykit/build.gradle
@@ -4,6 +4,15 @@ plugins {
   id("com.google.devtools.ksp").version("1.6.21-1.0.5")
 }
 
+def LIB_GROUP_ID = 'app.cash.paykit'
+def LIB_ARTIFACT_ID = 'core'
+def LIB_VERSION = '0.0.1-SNAPSHOT'
+
+task sourceJar(type: Jar) {
+  from android.sourceSets.main.java.srcDirs
+  classifier "sources"
+}
+
 android {
   namespace 'com.squareup.cash.paykit'
   compileSdk 31
@@ -17,6 +26,13 @@ android {
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
+
+    publishing {
+      singleVariant("release") {
+        withSourcesJar()
+        withJavadocJar()
+      }
+    }
   }
 
   buildTypes {
@@ -47,6 +63,32 @@ android {
     unitTests {
       returnDefaultValues = true
       includeAndroidResources = true
+    }
+  }
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        groupId LIB_GROUP_ID
+        artifactId LIB_ARTIFACT_ID
+        version LIB_VERSION
+        artifact("$buildDir/outputs/aar/paykit-release.aar")
+        artifact(sourceJar)
+
+        pom.withXml {
+          def dependenciesNode = asNode().appendNode('dependencies')
+          configurations.implementation.allDependencies.each { dependency ->
+            if (dependency.name != 'unspecified') {
+              def dependencyNode = dependenciesNode.appendNode('dependency')
+              dependencyNode.appendNode('groupId', dependency.group)
+              dependencyNode.appendNode('artifactId', dependency.name)
+              dependencyNode.appendNode('version', dependency.version)
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/paykit/build.gradle
+++ b/paykit/build.gradle
@@ -37,7 +37,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled true
+      minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/cashappcash/Upload-SDK-to-Artifactory-702799e71f424c6d85bf3a93d5d72d1c)

# Deployment

The SDK artifacts will be deployed to artifactory in the [[releases repository](https://artifactory.global.square/ui/repos/tree/General/releases/)](https://artifactory.global.square/ui/repos/tree/General/releases/) 

(alongside other cash app android specific artifacts (redwood, paparazzi, contour, etc))

The group id will be

`app.cash.paykit`

The artifact name will be

`core`


- [x] Get signoff from #cash-android 