### PR TITLE
Assert customer data when trying to authorize

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     lifecycle_version = '2.5.1'
     mockk_version = '1.13.3'
     coroutines_test_version = '1.6.4'
-    robolectric_version = '4.9'
+    robolectric_version = '4.9.2'
     mockwebserver_version = '4.10.0'
   }
 }

--- a/dev-app/src/main/java/com/squareup/cash/paykit/devapp/MainActivity.kt
+++ b/dev-app/src/main/java/com/squareup/cash/paykit/devapp/MainActivity.kt
@@ -3,8 +3,8 @@ package com.squareup.cash.paykit.devapp
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.viewModels
 import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle

--- a/dev-app/src/main/java/com/squareup/cash/paykit/devapp/MainActivity.kt
+++ b/dev-app/src/main/java/com/squareup/cash/paykit/devapp/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
       authorizeCustomerBtn.setOnClickListener {
         try {
           viewModel.authorizeCustomerRequest(this@MainActivity)
-        } catch (error: IllegalArgumentException) {
+        } catch (error: Exception) {
           Toast.makeText(this@MainActivity, error.message, Toast.LENGTH_LONG).show()
         }
       }

--- a/dev-app/src/main/java/com/squareup/cash/paykit/devapp/MainActivity.kt
+++ b/dev-app/src/main/java/com/squareup/cash/paykit/devapp/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.viewModels
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -63,7 +64,11 @@ class MainActivity : AppCompatActivity() {
       }
 
       authorizeCustomerBtn.setOnClickListener {
-        viewModel.authorizeCustomerRequest(this@MainActivity)
+        try {
+          viewModel.authorizeCustomerRequest(this@MainActivity)
+        } catch (error: IllegalArgumentException) {
+          Toast.makeText(this@MainActivity, error.message, Toast.LENGTH_LONG).show()
+        }
       }
 
       // Toggle Buttons.

--- a/paykit/src/main/java/com/squareup/cash/paykit/CashAppPayKit.kt
+++ b/paykit/src/main/java/com/squareup/cash/paykit/CashAppPayKit.kt
@@ -1,5 +1,6 @@
 package com.squareup.cash.paykit
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -122,7 +123,7 @@ class CashAppPayKit(
    * This function will set this SDK instance internal state to the `customerData` provided here as a function parameter.
    *
    */
-  @Throws(IllegalArgumentException::class)
+  @Throws(IllegalArgumentException::class, RuntimeException::class)
   fun authorizeCustomerRequest(
     context: Context,
     customerData: CustomerResponseData,
@@ -146,7 +147,11 @@ class CashAppPayKit(
     // Register for process lifecycle updates.
     PayKitLifecycleObserver.register(this)
 
-    context.startActivity(intent)
+    try {
+      context.startActivity(intent)
+    } catch (activityNotFoundException: ActivityNotFoundException) {
+      throw RuntimeException("unable to open mobileUrl")
+    }
     currentState = Authorizing
   }
 

--- a/paykit/src/main/java/com/squareup/cash/paykit/CashAppPayKit.kt
+++ b/paykit/src/main/java/com/squareup/cash/paykit/CashAppPayKit.kt
@@ -56,14 +56,6 @@ class CashAppPayKit(
     }
   }
 
-  init {
-    if (useSandboxEnvironment) {
-      NetworkManager.baseUrl = BASE_URL_SANDBOX
-    } else {
-      NetworkManager.baseUrl = BASE_URL_PRODUCTION
-    }
-  }
-
   /**
    * Create customer request given a [PayKitPaymentAction].
    * Must be called from a background thread.

--- a/paykit/src/test/java/com/squareup/cash/paykit/CashAppPayKitAuthorizeTests.kt
+++ b/paykit/src/test/java/com/squareup/cash/paykit/CashAppPayKitAuthorizeTests.kt
@@ -1,0 +1,94 @@
+package com.squareup.cash.paykit
+
+import android.content.Context
+import com.squareup.cash.paykit.PayKitState.Authorizing
+import com.squareup.cash.paykit.exceptions.PayKitIntegrationException
+import com.squareup.cash.paykit.models.response.CustomerResponseData
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Robolectric is used for the Lifecycle observer
+ */
+@RunWith(RobolectricTestRunner::class)
+class CashAppPayKitAuthorizeTests {
+
+  @MockK(relaxed = true)
+  private lateinit var context: Context
+
+  @Before
+  fun setup() {
+    MockKAnnotations.init(this)
+  }
+
+  @Test(expected = PayKitIntegrationException::class)
+  fun `should throw if calling authorize before createCustomer`() {
+    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
+    payKit.registerForStateUpdates(mockk())
+    payKit.authorizeCustomerRequest(context)
+  }
+
+  @Test(expected = PayKitIntegrationException::class)
+  fun `should throw on authorizeCustomerRequest if has NOT registered for state updates`() {
+    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
+    val customerResponseData = mockk<CustomerResponseData>(relaxed = true)
+    payKit.authorizeCustomerRequest(context, customerResponseData)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw if missing mobileUrl from customer data`() {
+    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
+    val customerResponseData = mockk<CustomerResponseData>(relaxed = true)
+    payKit.registerForStateUpdates(mockk())
+
+    payKit.authorizeCustomerRequest(context, customerResponseData)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw if unable to parse mobile url in customer data`() {
+    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
+    val customerResponseData = mockk<CustomerResponseData>(relaxed = true) {
+      every { authFlowTriggers } returns null
+    }
+    payKit.registerForStateUpdates(mockk())
+
+    payKit.authorizeCustomerRequest(context, customerResponseData)
+  }
+
+  @Test(expected = RuntimeException::class)
+  fun `should throw on if unable to start mobileUrl activity`() {
+    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
+    val customerResponseData = mockk<CustomerResponseData>(relaxed = true) {
+      every { authFlowTriggers } returns mockk {
+        every { mobileUrl } returns "http://url"
+      }
+    }
+    payKit.registerForStateUpdates(mockk())
+
+    payKit.authorizeCustomerRequest(context, customerResponseData)
+  }
+
+  @Test
+  fun `happy path`() {
+    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
+    val customerResponseData = mockk<CustomerResponseData>(relaxed = true) {
+      every { authFlowTriggers } returns mockk {
+        every { mobileUrl } returns "http://url"
+      }
+    }
+    val listener = mockk<CashAppPayKitListener>(relaxed = true)
+    payKit.registerForStateUpdates(listener)
+
+    payKit.authorizeCustomerRequest(context, customerResponseData)
+
+    verify { context.startActivity(any()) }
+    verify { listener.payKitStateDidChange(Authorizing) }
+  }
+}

--- a/paykit/src/test/java/com/squareup/cash/paykit/CashAppPayKitExceptionsTests.kt
+++ b/paykit/src/test/java/com/squareup/cash/paykit/CashAppPayKitExceptionsTests.kt
@@ -1,68 +1,9 @@
 package com.squareup.cash.paykit
 
 import com.squareup.cash.paykit.exceptions.PayKitIntegrationException
-import com.squareup.cash.paykit.models.response.CustomerResponseData
-import io.mockk.every
-import io.mockk.mockk
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
-@RunWith(RobolectricTestRunner::class)
 class CashAppPayKitExceptionsTests {
-
-  @Test(expected = PayKitIntegrationException::class)
-  fun `should throw if calling authorize before createCustomer`() {
-    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
-    payKit.registerForStateUpdates(mockk())
-    val appContext = RuntimeEnvironment.getApplication()
-    payKit.authorizeCustomerRequest(appContext)
-  }
-
-  @Test(expected = PayKitIntegrationException::class)
-  fun `should throw on authorizeCustomerRequest if has NOT registered for state updates`() {
-    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
-    val customerResponseData = mockk<CustomerResponseData>(relaxed = true)
-    val appContext = RuntimeEnvironment.getApplication()
-    payKit.authorizeCustomerRequest(appContext, customerResponseData)
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw if missing mobileUrl from customer data`() {
-    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
-    val customerResponseData = mockk<CustomerResponseData>(relaxed = true)
-    val appContext = RuntimeEnvironment.getApplication()
-    payKit.registerForStateUpdates(mockk())
-
-    payKit.authorizeCustomerRequest(appContext, customerResponseData)
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw if unable to parse mobile url in customer data`() {
-    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
-    val customerResponseData = mockk<CustomerResponseData>(relaxed = true) {
-      every { authFlowTriggers } returns null
-    }
-    val appContext = RuntimeEnvironment.getApplication()
-    payKit.registerForStateUpdates(mockk())
-
-    payKit.authorizeCustomerRequest(appContext, customerResponseData)
-  }
-
-  @Test(expected = RuntimeException::class)
-  fun `should throw on if unable to start mobileUrl activity`() {
-    val payKit = CashAppPayKit(FakeData.CLIENT_ID, useSandboxEnvironment = true)
-    val customerResponseData = mockk<CustomerResponseData>(relaxed = true) {
-      every { authFlowTriggers } returns mockk {
-        every { mobileUrl } returns "http://url"
-      }
-    }
-    val appContext = RuntimeEnvironment.getApplication()
-    payKit.registerForStateUpdates(mockk())
-
-    payKit.authorizeCustomerRequest(appContext, customerResponseData)
-  }
 
   @Test(expected = PayKitIntegrationException::class)
   fun `should throw on createCustomerRequest if has NOT registered for state updates`() {

--- a/paykit/src/test/java/com/squareup/cash/paykit/CashAppPayKitExceptionsTests.kt
+++ b/paykit/src/test/java/com/squareup/cash/paykit/CashAppPayKitExceptionsTests.kt
@@ -1,7 +1,6 @@
 package com.squareup.cash.paykit
 
 import com.squareup.cash.paykit.exceptions.PayKitIntegrationException
-import com.squareup.cash.paykit.models.response.AuthFlowTriggers
 import com.squareup.cash.paykit.models.response.CustomerResponseData
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
This fixed a bug where a client could try and call authorize with malformed data. 

This bug occurred when I completed one authorization, and simply pressed the "authorize" button again, which caused it to crash, because the authFlowTriggers was removed from our internal state. 

A future optimization might be to check the current state value, and only try to authorize if state conditions are met.