### PR TITLE
Add html gradle dependency reporting

### DIFF
--- a/paykit/build.gradle
+++ b/paykit/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'com.android.library'
   id 'org.jetbrains.kotlin.android'
   id("com.google.devtools.ksp").version("1.6.21-1.0.5")
+  id 'project-report' // run ./gradlew htmlDependencyReport
 }
 
 def LIB_GROUP_ID = 'app.cash.paykit'


### PR DESCRIPTION
run `./gradlew htmlDependencyReport` to view the dependencies in HTML

![image](https://user-images.githubusercontent.com/2036206/211096071-84e7854c-ab8f-40fc-a8fb-07f6fd94bb7d.png)
