### PR TITLE
Language header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![release](https://github.com/cashapp/android-cash-paykit-sdk/actions/workflows/release.yaml/badge.svg)](https://github.com/cashapp/android-cash-paykit-sdk/actions/workflows/release.yaml)
+[![release](https://github.com/cashapp/android-cash-paykit-sdk/actions/workflows/release.yaml/badge.svg)](https://github.com/cashapp/android-cash-paykit-sdk/actions/workflows/release.yaml) ![License](https://img.shields.io/github/license/cashapp/cash-pay-kit-sdk-android-sample-app?style=plastic) 
 
 # About
 

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -183,6 +183,7 @@ internal class NetworkManagerImpl(
       .url(endpointUrl)
       .addHeader("Content-Type", "application/json")
       .addHeader("Accept", "application/json")
+      .addHeader("Accept-Language", Locale.getDefault().toLanguageTag())
       .addHeader("User-Agent", userAgentValue)
 
     if (clientId != null) {


### PR DESCRIPTION
This PR adds the `Accept-Language` HTTP Header to all network requests.

Rationale: Since all the network requests are currently consolidated into a single function call, there's no need to create an Interceptor, so I went with the simpler yet still maintainable solution.

# Verification

![Screenshot_20230216_114927](https://user-images.githubusercontent.com/416941/219471873-8d5ac634-62b1-402a-8827-cfa824ae90ad.png)
