### PR TITLE
Add missing fields to analytics

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -267,9 +267,10 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       originId = customerResponseData?.origin?.id,
       requestChannel = CHANNEL_IN_APP,
       approvedGrants = customerResponseData?.grants?.joinToString(),
-      referenceId = customerResponseData?.id,
       customerId = customerResponseData?.customerProfile?.id,
       customerCashTag = customerResponseData?.customerProfile?.cashTag,
+      requestId = customerResponseData?.id,
+      referenceId = customerResponseData?.referenceId,
     )
   }
 

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
@@ -50,4 +50,6 @@ data class CustomerResponseData(
   val customerProfile: CustomerProfile?,
   @Json(name = "grants")
   val grants: List<Grant>?,
+  @Json(name = "reference_id")
+  val referenceId: String?,
 )


### PR DESCRIPTION
 - Add missing `request-id` to analytics
 - Additionally, adding an optional field on `reference-id` to the customer data response



# Verification

![request-id-to-analytics](https://user-images.githubusercontent.com/416941/219793270-6fb0b22e-0cac-4513-9d31-4507d4d9d0a2.png)
