### PR TITLE
Handle inability to open mobileUrl in a smooth manner

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/PayKitState.kt
+++ b/core/src/main/java/app/cash/paykit/core/PayKitState.kt
@@ -83,5 +83,5 @@ sealed interface PayKitState {
    * This state is typically unrecoverable, and it is advised to restart the process from scratch in
    * case it is met.
    */
-  class PayKitException(val exception: Exception) : PayKitState
+  class PayKitExceptionState(val exception: Exception) : PayKitState
 }

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
@@ -19,7 +19,7 @@ package app.cash.paykit.core.analytics
 
 import app.cash.paykit.core.PayKitState
 import app.cash.paykit.core.PayKitState.Approved
-import app.cash.paykit.core.PayKitState.PayKitException
+import app.cash.paykit.core.PayKitState.PayKitExceptionState
 import app.cash.paykit.core.models.common.Action
 import app.cash.paykit.core.models.response.CustomerResponseData
 import app.cash.paykit.core.models.sdk.PayKitPaymentAction
@@ -51,7 +51,7 @@ internal interface PayKitAnalyticsEventDispatcher {
   fun stateApproved(approved: Approved)
 
   fun exceptionOccurred(
-    payKitException: PayKitException,
+    payKitExceptionState: PayKitExceptionState,
     customerResponseData: CustomerResponseData?,
   )
 }

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -29,7 +29,7 @@ import app.cash.paykit.core.PayKitState.Authorizing
 import app.cash.paykit.core.PayKitState.CreatingCustomerRequest
 import app.cash.paykit.core.PayKitState.Declined
 import app.cash.paykit.core.PayKitState.NotStarted
-import app.cash.paykit.core.PayKitState.PayKitException
+import app.cash.paykit.core.PayKitState.PayKitExceptionState
 import app.cash.paykit.core.PayKitState.PollingTransactionStatus
 import app.cash.paykit.core.PayKitState.ReadyToAuthorize
 import app.cash.paykit.core.PayKitState.RetrievingExistingCustomerRequest
@@ -161,14 +161,14 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   }
 
   override fun exceptionOccurred(
-    payKitException: PayKitException,
+    payKitExceptionState: PayKitExceptionState,
     customerResponseData: CustomerResponseData?,
   ) {
     var eventPayload =
-      eventFromCustomerResponseData(customerResponseData).copy(action = stateToAnalyticsAction(payKitException))
+      eventFromCustomerResponseData(customerResponseData).copy(action = stateToAnalyticsAction(payKitExceptionState))
 
-    eventPayload = if (payKitException.exception is PayKitApiNetworkException) {
-      val apiError = payKitException.exception
+    eventPayload = if (payKitExceptionState.exception is PayKitApiNetworkException) {
+      val apiError = payKitExceptionState.exception
       eventPayload.copy(
         errorCode = apiError.code,
         errorCategory = apiError.category,
@@ -177,8 +177,8 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       )
     } else {
       eventPayload.copy(
-        errorCode = payKitException.exception.cause?.toString(),
-        errorDetail = payKitException.exception.message,
+        errorCode = payKitExceptionState.exception.cause?.toString(),
+        errorDetail = payKitExceptionState.exception.message,
       )
     }
 
@@ -295,7 +295,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       CreatingCustomerRequest -> "create"
       Declined -> "declined"
       NotStarted -> "not_started"
-      is PayKitException -> "paykit_exception"
+      is PayKitExceptionState -> "paykit_exception"
       PollingTransactionStatus -> "polling"
       is ReadyToAuthorize -> "ready_to_authorize"
       RetrievingExistingCustomerRequest -> "retrieve_existing_customer_request"

--- a/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
@@ -17,7 +17,7 @@
 
 package app.cash.paykit.core
 
-import app.cash.paykit.core.PayKitState.PayKitException
+import app.cash.paykit.core.PayKitState.PayKitExceptionState
 import app.cash.paykit.core.exceptions.PayKitApiNetworkException
 import app.cash.paykit.core.exceptions.PayKitConnectivityNetworkException
 import app.cash.paykit.core.impl.CashAppPayKitImpl
@@ -66,11 +66,11 @@ class NetworkErrorTests {
     payKit.createCustomerRequest(FakeData.oneTimePayment)
 
     // Verify that all the appropriate exception wrapping has occurred for a 503 error.
-    assertThat(mockListener.state).isInstanceOf(PayKitException::class.java)
-    assertThat((mockListener.state as PayKitException).exception).isInstanceOf(
+    assertThat(mockListener.state).isInstanceOf(PayKitExceptionState::class.java)
+    assertThat((mockListener.state as PayKitExceptionState).exception).isInstanceOf(
       PayKitConnectivityNetworkException::class.java,
     )
-    assertThat(((mockListener.state as PayKitException).exception as PayKitConnectivityNetworkException).e).isInstanceOf(
+    assertThat(((mockListener.state as PayKitExceptionState).exception as PayKitConnectivityNetworkException).e).isInstanceOf(
       IOException::class.java,
     )
   }
@@ -106,13 +106,13 @@ class NetworkErrorTests {
     payKit.createCustomerRequest(FakeData.oneTimePayment)
 
     // Verify that all the appropriate exception wrapping has occurred for a 400 error.
-    assertThat(mockListener.state).isInstanceOf(PayKitException::class.java)
-    assertThat((mockListener.state as PayKitException).exception).isInstanceOf(
+    assertThat(mockListener.state).isInstanceOf(PayKitExceptionState::class.java)
+    assertThat((mockListener.state as PayKitExceptionState).exception).isInstanceOf(
       PayKitApiNetworkException::class.java,
     )
 
     // Verify that all the API error details have been deserialized correctly.
-    val apiError = (mockListener.state as PayKitException).exception as PayKitApiNetworkException
+    val apiError = (mockListener.state as PayKitExceptionState).exception as PayKitApiNetworkException
     assertThat(apiError.code).isEqualTo("MISSING_REQUIRED_PARAMETER")
     assertThat(apiError.category).isEqualTo("INVALID_REQUEST_ERROR")
     assertThat(apiError.field_value).isEqualTo("request.action.amount")
@@ -145,7 +145,7 @@ class NetworkErrorTests {
     payKit.createCustomerRequest(FakeData.oneTimePayment)
 
     // Verify that a timeout error was captured and relayed to the SDK listener.
-    assertThat(((mockListener.state as PayKitException).exception as PayKitConnectivityNetworkException).e).isInstanceOf(
+    assertThat(((mockListener.state as PayKitExceptionState).exception as PayKitConnectivityNetworkException).e).isInstanceOf(
       InterruptedIOException::class.java,
     )
   }
@@ -204,8 +204,8 @@ class NetworkErrorTests {
     payKit.createCustomerRequest(FakeData.oneTimePayment)
 
     // Verify that we got the appropriate JSON deserialization error.
-    assertThat(mockListener.state).isInstanceOf(PayKitException::class.java)
-    assertThat((mockListener.state as PayKitException).exception).isInstanceOf(JsonDataException::class.java)
+    assertThat(mockListener.state).isInstanceOf(PayKitExceptionState::class.java)
+    assertThat((mockListener.state as PayKitExceptionState).exception).isInstanceOf(JsonDataException::class.java)
   }
 
   /**

--- a/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
@@ -18,7 +18,7 @@
 package app.cash.paykit.core
 
 import app.cash.paykit.core.NetworkErrorTests.MockListener
-import app.cash.paykit.core.PayKitState.PayKitException
+import app.cash.paykit.core.PayKitState.PayKitExceptionState
 import app.cash.paykit.core.PayKitState.ReadyToAuthorize
 import app.cash.paykit.core.exceptions.PayKitConnectivityNetworkException
 import app.cash.paykit.core.impl.CashAppPayKitImpl
@@ -97,7 +97,7 @@ class NetworkRetryTests {
 
     // We should retry twice, and then stop retrying. If the number of retries is correct,
     // we should have reached a `PayKitException` and NOT a `ReadyToAuthorize` state.
-    assertThat(mockListener.state).isInstanceOf(PayKitException::class.java)
+    assertThat(mockListener.state).isInstanceOf(PayKitExceptionState::class.java)
   }
 
   @Test
@@ -167,7 +167,7 @@ class NetworkRetryTests {
     payKit.createCustomerRequest(FakeData.oneTimePayment)
 
     // Verify that a timeout error was captured and relayed to the SDK listener.
-    assertThat(((mockListener.state as PayKitException).exception as PayKitConnectivityNetworkException).e).isInstanceOf(
+    assertThat(((mockListener.state as PayKitExceptionState).exception as PayKitConnectivityNetworkException).e).isInstanceOf(
       InterruptedIOException::class.java,
     )
   }


### PR DESCRIPTION
Currently the `mobileUrl` on prod is of type `cashme://`. This will result in a throw -> crash for clients that do NOT have the Cash App installed. While separately we will look into ways to change this on the backend, we want to change the client SDKs such that they do not crash when this happens.

Changes:
 - Emit an exception state with `PayKitIntegrationException` instead of throwing an Exception at runtime.
 - Added Unit Test for the above condition.
 - Additionally, renamed `PayKitException` to `PayKitExceptionState` since it better reflects that it is a `PayKitState`, and not a class deriving from `Exception`.

## Verification 

On the screenshot below, the system did NOT have an app that was able to handle a `cashme://` link, and thus this is captured by a PayKitExceptionState as expected:

![mobile-url-exception](https://user-images.githubusercontent.com/416941/220484357-d4675854-863e-41c7-a7da-add3947d88fc.png)
