### PR TITLE
Use Epoch usec for Analytics timestamp

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -50,6 +50,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 private const val APP_NAME = "paykitsdk-android"
 private const val PLATFORM = "android"
@@ -246,7 +247,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
         catalogName = catalog,
         uuid = UUID.randomUUID().toString(),
         jsonData = jsonData,
-        recordedAt = System.nanoTime() * 10,
+        recordedAt = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()),
       )
 
     // Transform ES2 event into a JSON String.


### PR DESCRIPTION
Analytics timestamps were not using a correct epoch `usec` time format. This PR addresses that.

## Verification

<img width="1278" alt="Screenshot 2023-06-05 at 11 14 49 AM" src="https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/cb139fdc-81e7-4bcc-986a-f952fd5b2b02">

Tested this solution on Android 9 for backwards compatibility.
