### PR TITLE
Update Maven Publishing and ready SNAPSHOT release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,5 @@
 name: release
 
-# TODO we could consider creating a github release
-# https://www.notion.so/cashappcash/Change-github-triggers-to-build-on-new-Github-Release-8c3da4ce779e440299908e7ec734626a
-# from zipline - https://github.com/cashapp/zipline/blob/trunk/.github/workflows/release.yaml#LL111C7-L130C22
-
 on:
   workflow_dispatch:
   push:
@@ -36,6 +32,7 @@ jobs:
           ./gradlew clean publish --stacktrace
 
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# NEXT RELEASE | WIP
+# 3.0.0
 ## Breaking Changes
  - Our internal implementation no longer depends on `kotlinx-datetime`, and now uses Java 8 time classes,
 namely `java.time.Instant`.

--- a/analytics-core/build.gradle.kts
+++ b/analytics-core/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
@@ -31,8 +32,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
+  kotlin {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
+    }
   }
 
   kotlin {
@@ -63,6 +66,5 @@ dependencies {
 }
 
 mavenPublishing {
-  // AndroidMultiVariantLibrary(publish a sources jar, publish a javadoc jar)
   configure(AndroidSingleVariantLibrary("release", sourcesJar = true, publishJavadocJar = true))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import com.vanniktech.maven.publish.SonatypeHost
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
@@ -14,7 +13,7 @@ plugins {
 
 subprojects {
   group = "app.cash.paykit"
-  version = "2.6.1-SNAPSHOT"
+  version = "3.0.0-SNAPSHOT"
 
   apply(plugin = "com.diffplug.spotless")
   extensions.configure<SpotlessExtension> {
@@ -40,7 +39,7 @@ subprojects {
   plugins.withId("com.vanniktech.maven.publish.base") {
     apply(plugin = "binary-compatibility-validator")
     extensions.configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+      publishToMavenCentral(automaticRelease = true)
       signAllPublications()
       pom {
         description.set("Cash App Pay SDK")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
@@ -38,8 +39,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
+  kotlin {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
+    }
   }
 
   kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ agp = "8.13.2"
 kotlin = "2.2.21"
 ksp = "2.2.21-2.0.4"
 spotless = "8.2.0"
-mavenPublish = "0.32.0"
+mavenPublish = "0.35.0"
 binaryCompatibilityValidator = "0.18.1"
 
 # Compose Versions

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -1,4 +1,6 @@
+import com.android.tools.analytics.AnalyticsSettings
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
@@ -7,7 +9,7 @@ plugins {
 }
 
 // https://issuetracker.google.com/issues/226095015
-com.android.tools.analytics.AnalyticsSettings.optedIn = false
+AnalyticsSettings.optedIn = false
 
 android {
   namespace = "app.cash.paykit.logging"
@@ -31,8 +33,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
+  kotlin {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
+    }
   }
 
   lint {
@@ -51,6 +55,5 @@ dependencies {
 }
 
 mavenPublishing {
-  // AndroidMultiVariantLibrary(publish a sources jar, publish a javadoc jar)
   configure(AndroidSingleVariantLibrary("release", sourcesJar = true, publishJavadocJar = true))
 }

--- a/ui-compose/build.gradle.kts
+++ b/ui-compose/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
@@ -27,8 +28,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
+  kotlin {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
+    }
   }
 
   resourcePrefix = "cap_compose_"

--- a/ui-views/build.gradle.kts
+++ b/ui-views/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
@@ -26,8 +27,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
+  kotlin {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
+    }
   }
 
   resourcePrefix = "cap_"


### PR DESCRIPTION
Followed new Maven instructions here: https://www.notion.so/cashappcash/Sonatype-Central-Portal-migration-1f154e8e103180018320f3e105c63a49